### PR TITLE
fix: registry sig reusage

### DIFF
--- a/contracts/clearing/YellowClearingBase.sol
+++ b/contracts/clearing/YellowClearingBase.sol
@@ -124,7 +124,11 @@ abstract contract YellowClearingBase is AccessControl {
 		return _participantData[participant].status != ParticipantStatus.None;
 	}
 
-	// todo: add doc comment
+	/**
+	 * @notice Recursively check that participant is not present in this registry and all previous ones.
+	 * @dev Recursively check that participant is not present in this registry and all previous ones.
+	 * @param participant Address of participant to check.
+	 */
 	function requireParticipantNotPresentBackwards(address participant) public view {
 		if (address(_prevImplementation) != address(0)) {
 			_prevImplementation.requireParticipantNotPresentBackwards(participant);
@@ -133,7 +137,11 @@ abstract contract YellowClearingBase is AccessControl {
 		_requireParticipantNotPresent(participant);
 	}
 
-	// todo: add doc comment
+	/**
+	 * @notice Recursively check that participant is not present in this registry and all subsequent ones.
+	 * @dev Recursively check that participant is not present in this registry and all subsequent ones.
+	 * @param participant Address of participant to check.
+	 */
 	function requireParticipantNotPresentForwards(address participant) public view {
 		if (address(_nextImplementation) != address(0)) {
 			_nextImplementation.requireParticipantNotPresentForwards(participant);
@@ -143,8 +151,8 @@ abstract contract YellowClearingBase is AccessControl {
 	}
 
 	/**
-	 * @notice Recursively check that participant is not present in this registry and any subsequent.
-	 * @dev Recursively check that participant is not present in this registry and all subsequent.
+	 * @notice Recursively check that participant is not present in this registry and all previous and subsequent ones.
+	 * @dev Recursively check that participant is not present in this registry and all previous and subsequent ones.
 	 * @param participant Address of participant to check.
 	 */
 	function requireParticipantNotPresentRecursive(address participant) public view {
@@ -168,7 +176,12 @@ abstract contract YellowClearingBase is AccessControl {
 		return _participantData[participant];
 	}
 
-	// todo: add doc comments
+	/**
+	 * @notice Return interaction payload structure for a supplied participant. Used to ease interaction with this contract.
+	 * @dev Participant must be present.
+	 * @param participant Address of participant to get interaction payload for.
+	 * @return InteractionPayload Interaction payload structure for a supplied participant.
+	 */
 	function getInteractionPayload(address participant)
 		external
 		view
@@ -188,12 +201,11 @@ abstract contract YellowClearingBase is AccessControl {
 	// participant changes
 	// ======================
 
-	// todo: change comment
 	/**
 	 * @notice Register participant by adding it to the registry with Pending status. Emit `ParticipantRegistered` event.
-	 * @dev Participant must not be present in this or any subsequent implementations.
+	 * @dev Participant must not be present in this or any previous or subsequent implementations.
 	 * @param participant Virtual (no address, only public key exist) address of participant to add.
-	 * @param signature Participant virtual address signed by this same participant.
+	 * @param signature Participant interaction payload signed by this same participant.
 	 */
 	function registerParticipant(address participant, bytes calldata signature) external {
 		requireParticipantNotPresentRecursive(participant);
@@ -304,12 +316,11 @@ abstract contract YellowClearingBase is AccessControl {
 	// migrate participant
 	// ======================
 
-	// todo: change comment
 	/**
 	 * @notice Migrate participant to the newest implementation present in upgrades chain. Emit `ParticipantMigratedFrom` and `ParticipantMigratedTo` events.
 	 * @dev NextImplementation must have been set. Participant must not have been migrated.
 	 * @param participant Address of participant to migrate.
-	 * @param signature Participant address signed by that participant.
+	 * @param signature Participant interaction payload signed by that participant.
 	 */
 	function migrateParticipant(address participant, bytes calldata signature) external {
 		require(address(_nextImplementation) != address(0), 'Next implementation is not set');
@@ -371,24 +382,31 @@ abstract contract YellowClearingBase is AccessControl {
 	// internal functions
 	// ======================
 
-	// todo: add doc comment
+	/**
+	 * @notice Require participant it present in this registry.
+	 * @dev Require participant it present in this registry.
+	 * @param participant Address of participant to check.
+	 */
 	function _requireParticipantPresent(address participant) internal view {
 		require(hasParticipant(participant), 'Participant does not exist');
 	}
 
-	// todo: add doc comment
+	/**
+	 * @notice Require participant it not present in this registry.
+	 * @dev Require participant it not present in this registry.
+	 * @param participant Address of participant to check.
+	 */
 	function _requireParticipantNotPresent(address participant) internal view {
 		require(!hasParticipant(participant), 'Participant already exist');
 	}
 
-	// todo: change comment
-	// /**
-	//  * @notice Recover signer of the address.
-	//  * @dev Recover signer of the address.
-	//  * @param _address Address to be signed.
-	//  * @param signature Signed address.
-	//  * @return address Address of the signer.
-	//  */
+	/**
+	 * @notice Recover signer of interaction payload.
+	 * @dev Recover signer of interaction payload.
+	 * @param interactionPayload Interaction payload that has been signed.
+	 * @param signature Signed interaction payload.
+	 * @return address Address of the signer.
+	 */
 	function _recoverInteractionSigner(
 		InteractionPayload memory interactionPayload,
 		bytes memory signature

--- a/contracts/clearing/YellowClearingBase.sol
+++ b/contracts/clearing/YellowClearingBase.sol
@@ -178,7 +178,7 @@ abstract contract YellowClearingBase is AccessControl {
 
 	/**
 	 * @notice Return interaction payload structure for a supplied participant. Used to ease interaction with this contract.
-	 * @dev Participant must be present.
+	 * @dev Return interaction payload structure for a supplied participant. Used to ease interaction with this contract.
 	 * @param participant Address of participant to get interaction payload for.
 	 * @return InteractionPayload Interaction payload structure for a supplied participant.
 	 */
@@ -187,13 +187,19 @@ abstract contract YellowClearingBase is AccessControl {
 		view
 		returns (InteractionPayload memory)
 	{
-		_requireParticipantPresent(participant);
+		uint64 nonce;
+
+		if (!hasParticipant(participant)) {
+			nonce = 0;
+		} else {
+			nonce = _participantData[participant].nonce + 1;
+		}
 
 		return
 			InteractionPayload({
 				YellowClearing: YellowClearingBase(_self),
 				participant: participant,
-				nonce: _participantData[participant].nonce + 1
+				nonce: nonce
 			});
 	}
 

--- a/contracts/clearing/YellowClearingBase.sol
+++ b/contracts/clearing/YellowClearingBase.sol
@@ -68,8 +68,8 @@ abstract contract YellowClearingBase is AccessControl {
 
 		_prevImplementation = previousImplementation;
 
-		if (address(previousImplementation) != address(0)) {
-			_grantRole(PREVIOUS_IMPLEMENTATION_ROLE, address(previousImplementation));
+		if (address(_prevImplementation) != address(0)) {
+			_grantRole(PREVIOUS_IMPLEMENTATION_ROLE, address(_prevImplementation));
 		}
 	}
 

--- a/contracts/clearing/test/TESTYellowClearingV3.sol
+++ b/contracts/clearing/test/TESTYellowClearingV3.sol
@@ -13,7 +13,7 @@ contract TESTYellowClearingV3 is YellowClearingBase {
 		internal
 		override
 	{
-		ParticipantData memory migratedData = ParticipantData(42, data.status);
+		ParticipantData memory migratedData = ParticipantData(data.status, data.nonce, 42);
 
 		_participantData[participant] = migratedData;
 	}

--- a/src/revert-reasons.ts
+++ b/src/revert-reasons.ts
@@ -1,4 +1,4 @@
-import {utils} from 'ethers';
+import { utils } from 'ethers';
 
 const hexify = utils.hexlify;
 
@@ -29,7 +29,7 @@ export const INVALID_CHAIN_ID = 'Invalid chain id';
 // network registry
 export const NEXT_IMPL_ALREADY_SET = 'Next implementation already set';
 export const PREV_IMPL_ROLE_REQUIRED = 'Previous implementation role is required';
-export const PARTICIPANT_ALREADY_REGISTERED = 'Participant already registered';
+export const PARTICIPANT_ALREADY_EXIST = 'Participant already exist';
 export const NO_PARTICIPANT = 'Participant does not exist';
 export const INVALID_SIGNER = 'Invalid signer';
 export const INVALID_STATUS = 'Invalid status';

--- a/test/clearing/NetworkRegistry.spec.ts
+++ b/test/clearing/NetworkRegistry.spec.ts
@@ -110,7 +110,7 @@ describe('Network Registry', () => {
     });
 
     it('If prev impl is not 0, set PREV_IMPL role', async () => {
-      const RegistryV2 = await deployNextRegistry(2, RegistryV1, registryAdmin);
+      const RegistryV2 = await deployNextRegistry(RegistryV1, 2, registryAdmin);
       expect(await RegistryV2.hasRole(PREV_IMPL_ROLE, RegistryV1.address)).to.be.true;
     });
   });
@@ -121,7 +121,7 @@ describe('Network Registry', () => {
     });
 
     it('Return correct impl address after it has been set', async () => {
-      const RegistryV2 = await deployNextRegistry(2, RegistryV1, registryAdmin);
+      const RegistryV2 = await deployNextRegistry(RegistryV1, 2, registryAdmin);
       await RegistryV1.setNextImplementation(RegistryV2.address);
 
       expect(await RegistryV1.getNextImplementation()).to.equal(RegistryV2.address);
@@ -132,7 +132,7 @@ describe('Network Registry', () => {
     let RegistryV2: TESTYellowClearingV2;
 
     beforeEach(async () => {
-      RegistryV2 = (await deployNextRegistry(2, RegistryV1, registryAdmin)) as TESTYellowClearingV2;
+      RegistryV2 = (await deployNextRegistry(RegistryV1, 2, registryAdmin)) as TESTYellowClearingV2;
     });
 
     it('Succeed if caller is admin and address is correct', async () => {
@@ -205,7 +205,7 @@ describe('Network Registry', () => {
     });
 
     it('Succeed if participant is not present in this and prev impl', async () => {
-      const RegistryV2 = await deployAndLinkNextRegistry(2, RegistryV1, registryAdmin);
+      const RegistryV2 = await deployAndLinkNextRegistry(RegistryV1);
 
       await expect(
         RegistryV2.connect(someone).requireParticipantNotPresentBackwards(
@@ -215,8 +215,8 @@ describe('Network Registry', () => {
     });
 
     it('Succeed if participant is not present in this and 2 prev impl', async () => {
-      const RegistryV2 = await deployAndLinkNextRegistry(2, RegistryV1, registryAdmin);
-      const RegistryV3 = await deployAndLinkNextRegistry(3, RegistryV2, registryAdmin);
+      const RegistryV2 = await deployAndLinkNextRegistry(RegistryV1);
+      const RegistryV3 = await deployAndLinkNextRegistry(RegistryV2);
 
       await expect(
         RegistryV3.connect(someone).requireParticipantNotPresentBackwards(
@@ -232,7 +232,7 @@ describe('Network Registry', () => {
     });
 
     it('Revert if participant is present in prev impl', async () => {
-      const RegistryV2 = await deployAndLinkNextRegistry(2, RegistryV1, registryAdmin);
+      const RegistryV2 = await deployAndLinkNextRegistry(RegistryV1);
 
       await expect(
         RegistryV2.connect(someone).requireParticipantNotPresentBackwards(activePartipant.address),
@@ -240,8 +240,8 @@ describe('Network Registry', () => {
     });
 
     it('Revert if participant is present in 2nd prev impl', async () => {
-      const RegistryV2 = await deployAndLinkNextRegistry(2, RegistryV1, registryAdmin);
-      const RegistryV3 = await deployAndLinkNextRegistry(3, RegistryV2, registryAdmin);
+      const RegistryV2 = await deployAndLinkNextRegistry(RegistryV1);
+      const RegistryV3 = await deployAndLinkNextRegistry(RegistryV2);
 
       await expect(
         RegistryV3.connect(someone).requireParticipantNotPresentBackwards(activePartipant.address),
@@ -256,15 +256,15 @@ describe('Network Registry', () => {
     });
 
     it('Succeed if participant is not present in this and next impls', async () => {
-      await deployAndLinkNextRegistry(2, RegistryV1, registryAdmin);
+      await deployAndLinkNextRegistry(RegistryV1);
 
       await expect(RegistryV1.requireParticipantNotPresentForwards(notPresentPartipant.address)).not
         .to.be.reverted;
     });
 
     it('Succeed if participant is not present in this and next impls', async () => {
-      const RegistryV2 = await deployAndLinkNextRegistry(2, RegistryV1, registryAdmin);
-      await deployAndLinkNextRegistry(3, RegistryV2, registryAdmin);
+      const RegistryV2 = await deployAndLinkNextRegistry(RegistryV1);
+      await deployAndLinkNextRegistry(RegistryV2);
 
       await expect(RegistryV1.requireParticipantNotPresentForwards(notPresentPartipant.address)).not
         .to.be.reverted;
@@ -277,7 +277,7 @@ describe('Network Registry', () => {
     });
 
     it('Revert if participant is present in next impl', async () => {
-      const RegistryV2 = await deployAndLinkNextRegistry(2, RegistryV1, registryAdmin);
+      const RegistryV2 = await deployAndLinkNextRegistry(RegistryV1);
       await setParticipantStatus(RegistryV2, someone, Status.Active);
 
       await expect(
@@ -286,8 +286,8 @@ describe('Network Registry', () => {
     });
 
     it('Revert if participant is present in 2nd next impl', async () => {
-      const RegistryV2 = await deployAndLinkNextRegistry(2, RegistryV1, registryAdmin);
-      const RegistryV3 = await deployAndLinkNextRegistry(3, RegistryV2, registryAdmin);
+      const RegistryV2 = await deployAndLinkNextRegistry(RegistryV1);
+      const RegistryV3 = await deployAndLinkNextRegistry(RegistryV2);
       await setParticipantStatus(RegistryV3, someone, Status.Active);
 
       await expect(
@@ -303,8 +303,8 @@ describe('Network Registry', () => {
     });
 
     it('Succeed if participant is not present in this, 1 prev and 1 next impls', async () => {
-      const middleRegistry = await deployAndLinkNextRegistry(1, RegistryV1);
-      await deployAndLinkNextRegistry(1, middleRegistry);
+      const middleRegistry = await deployAndLinkNextRegistry(RegistryV1);
+      await deployAndLinkNextRegistry(middleRegistry);
 
       await expect(
         middleRegistry.requireParticipantNotPresentRecursive(notPresentPartipant.address),
@@ -312,10 +312,10 @@ describe('Network Registry', () => {
     });
 
     it('Succeed if participant is not present in this, 2 prev and 2 next impls', async () => {
-      const prevRegistry = await deployAndLinkNextRegistry(1, RegistryV1);
-      const middleRegistry = await deployAndLinkNextRegistry(1, prevRegistry);
-      const nextRegistry = await deployAndLinkNextRegistry(1, middleRegistry);
-      await deployAndLinkNextRegistry(1, nextRegistry);
+      const prevRegistry = await deployAndLinkNextRegistry(RegistryV1);
+      const middleRegistry = await deployAndLinkNextRegistry(prevRegistry);
+      const nextRegistry = await deployAndLinkNextRegistry(middleRegistry);
+      await deployAndLinkNextRegistry(nextRegistry);
 
       await expect(
         middleRegistry.requireParticipantNotPresentRecursive(notPresentPartipant.address),
@@ -329,7 +329,7 @@ describe('Network Registry', () => {
     });
 
     it('Revert if participant is present in prev impl', async () => {
-      const RegistryV2 = await deployAndLinkNextRegistry(2, RegistryV1, registryAdmin);
+      const RegistryV2 = await deployAndLinkNextRegistry(RegistryV1);
 
       await expect(
         RegistryV2.connect(someone).requireParticipantNotPresentBackwards(activePartipant.address),
@@ -337,8 +337,8 @@ describe('Network Registry', () => {
     });
 
     it('Revert if participant is present in 2nd prev impl', async () => {
-      const RegistryV2 = await deployAndLinkNextRegistry(2, RegistryV1, registryAdmin);
-      const RegistryV3 = await deployAndLinkNextRegistry(3, RegistryV2, registryAdmin);
+      const RegistryV2 = await deployAndLinkNextRegistry(RegistryV1);
+      const RegistryV3 = await deployAndLinkNextRegistry(RegistryV2);
 
       await expect(
         RegistryV3.connect(someone).requireParticipantNotPresentBackwards(activePartipant.address),
@@ -346,7 +346,7 @@ describe('Network Registry', () => {
     });
 
     it('Revert if participant is present in next impl', async () => {
-      const RegistryV2 = await deployAndLinkNextRegistry(2, RegistryV1, registryAdmin);
+      const RegistryV2 = await deployAndLinkNextRegistry(RegistryV1);
       await setParticipantStatus(RegistryV2, someone, Status.Active);
 
       await expect(
@@ -355,8 +355,8 @@ describe('Network Registry', () => {
     });
 
     it('Revert if participant is present in 2nd next impl', async () => {
-      const RegistryV2 = await deployAndLinkNextRegistry(2, RegistryV1, registryAdmin);
-      const RegistryV3 = await deployAndLinkNextRegistry(3, RegistryV2, registryAdmin);
+      const RegistryV2 = await deployAndLinkNextRegistry(RegistryV1);
+      const RegistryV3 = await deployAndLinkNextRegistry(RegistryV2);
       await setParticipantStatus(RegistryV3, someone, Status.Active);
 
       await expect(
@@ -477,7 +477,7 @@ describe('Network Registry', () => {
     });
 
     it('Revert if participant is present in prev impl', async () => {
-      const nextRegistry = await deployAndLinkNextRegistry(1, RegistryV1);
+      const nextRegistry = await deployAndLinkNextRegistry(RegistryV1);
 
       const interactionPayload = await getInteractionPayload(RegistryV1, virtualParticipant);
       interactionPayload.YellowClearing = nextRegistry.address;
@@ -492,7 +492,7 @@ describe('Network Registry', () => {
     });
 
     it('Revert if participant is present in next impl', async () => {
-      const nextRegistry = await deployAndLinkNextRegistry(1, RegistryV1);
+      const nextRegistry = await deployAndLinkNextRegistry(RegistryV1);
 
       const v2ActiveParticipant = await randomSignerWithAddress();
       await setParticipantStatus(nextRegistry, v2ActiveParticipant, Status.Active);
@@ -674,12 +674,12 @@ describe('Network Registry', () => {
 
     beforeEach(async () => {
       RegistryV2 = (await deployAndLinkNextRegistry(
-        2,
         RegistryV1,
+        2,
         registryAdmin,
       )) as TESTYellowClearingV2;
 
-      RegistryV3 = (await deployNextRegistry(3, RegistryV2, registryAdmin)) as TESTYellowClearingV3;
+      RegistryV3 = (await deployNextRegistry(RegistryV2, 3, registryAdmin)) as TESTYellowClearingV3;
     });
 
     it('Succeed if all requirements are met', async () => {

--- a/test/clearing/src/deploy.ts
+++ b/test/clearing/src/deploy.ts
@@ -20,13 +20,6 @@ export async function deployNextRegistry(
   return _deployRegistry(version, { prevImpl, signer });
 }
 
-interface DeployRegistryOptions {
-  prevImpl?: YellowClearingBase;
-  signer?: Signer;
-  prevCallback?: (_: YellowClearingBase) => void;
-  thisCallback?: (_: YellowClearingBase) => void;
-}
-
 export async function deployAndLinkNextRegistry(
   version: number,
   prevImpl: YellowClearingBase,
@@ -44,8 +37,8 @@ export async function deployAndLinkNextRegistry(
 interface DeployRegistryOptions {
   prevImpl?: YellowClearingBase;
   signer?: Signer;
-  prevRegCallback?: (PrevRegistry: YellowClearingBase) => unknown;
-  thisRegCallback?: (NextRegistry: YellowClearingBase) => unknown;
+  prevCallback?: (PrevRegistry: YellowClearingBase) => unknown;
+  thisCallback?: (NextRegistry: YellowClearingBase) => unknown;
   callback?: (PrevRegistry: YellowClearingBase, NextRegistry: YellowClearingBase) => unknown;
 }
 
@@ -53,19 +46,19 @@ async function _deployRegistry(
   version: number,
   options: DeployRegistryOptions,
 ): Promise<YellowClearingBase> {
-  const { prevImpl, signer, prevRegCallback, thisRegCallback, callback } = options;
+  const { prevImpl, signer, prevCallback, thisCallback, callback } = options;
 
   const prevImplAddress = prevImpl ? prevImpl.address : AddressZero;
   const RegistryFactory = await ethers.getContractFactory(`TESTYellowClearingV${version}`, signer);
   const NextRegistry = (await RegistryFactory.deploy(prevImplAddress)) as YellowClearingBase;
   await NextRegistry.deployed();
 
-  if (prevImpl && prevRegCallback) {
-    await prevRegCallback(prevImpl);
+  if (prevImpl && prevCallback) {
+    await prevCallback(prevImpl);
   }
 
-  if (thisRegCallback) {
-    await thisRegCallback(NextRegistry);
+  if (thisCallback) {
+    await thisCallback(NextRegistry);
   }
 
   if (prevImpl && callback) {

--- a/test/clearing/src/deploy.ts
+++ b/test/clearing/src/deploy.ts
@@ -5,24 +5,21 @@ import type { YellowClearingBase } from '../../../typechain';
 
 const AddressZero = ethers.constants.AddressZero;
 
-export async function deployRegistry(
-  version: number,
-  signer?: Signer,
-): Promise<YellowClearingBase> {
+export async function deployRegistry(version = 1, signer?: Signer): Promise<YellowClearingBase> {
   return _deployRegistry(version, { signer });
 }
 
 export async function deployNextRegistry(
-  version: number,
   prevImpl: YellowClearingBase,
+  version = 1,
   signer?: Signer,
 ): Promise<YellowClearingBase> {
   return _deployRegistry(version, { prevImpl, signer });
 }
 
 export async function deployAndLinkNextRegistry(
-  version: number,
   prevImpl: YellowClearingBase,
+  version = 1,
   signer?: Signer,
 ): Promise<YellowClearingBase> {
   return _deployRegistry(version, {

--- a/test/clearing/src/identityPayload.ts
+++ b/test/clearing/src/identityPayload.ts
@@ -6,23 +6,23 @@ import type { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import type { BigNumber } from 'ethers';
 import type { YellowClearingBase } from '../../../typechain';
 
-export interface InteractionPayloadBN {
+export interface identityPayloadBN {
   YellowClearing: string;
   participant: string;
   nonce: BigNumber;
 }
 
-export interface InteractionPayload {
+export interface identityPayload {
   YellowClearing: string;
   participant: string;
   nonce: number;
 }
 
-export async function getInteractionPayload(
+export async function getIdentityPayload(
   registry: YellowClearingBase,
   participant: SignerWithAddress,
-): Promise<InteractionPayload> {
-  const IPBN = await registry.getInteractionPayload(participant.address);
+): Promise<identityPayload> {
+  const IPBN = await registry.getIdentityPayload(participant.address);
 
   return {
     YellowClearing: IPBN.YellowClearing,
@@ -31,8 +31,8 @@ export async function getInteractionPayload(
   };
 }
 
-export async function signInteractionPayload(
-  interactionPayload: InteractionPayload,
+export async function signIdentityPayload(
+  identityPayload: identityPayload,
   signer: SignerWithAddress,
 ): Promise<string> {
   const encodedIP = defaultAbiCoder.encode(
@@ -46,18 +46,18 @@ export async function signInteractionPayload(
         ],
       } as ParamType,
     ],
-    [interactionPayload],
+    [identityPayload],
   );
   return await signEncoded(signer, encodedIP);
 }
 
-type InteractionParams = [string, string];
+type IdentityParams = [string, string];
 
-export async function getAndSignInteractionPayload(
+export async function getAndSignIdentityPayload(
   registry: YellowClearingBase,
   participant: SignerWithAddress,
-): Promise<InteractionParams> {
-  const interactionPayload = await getInteractionPayload(registry, participant);
-  const sig = await signInteractionPayload(interactionPayload, participant);
+): Promise<IdentityParams> {
+  const identityPayload = await getIdentityPayload(registry, participant);
+  const sig = await signIdentityPayload(identityPayload, participant);
   return [participant.address, sig];
 }

--- a/test/clearing/src/interactionPayload.ts
+++ b/test/clearing/src/interactionPayload.ts
@@ -1,0 +1,63 @@
+import { type ParamType, defaultAbiCoder } from 'ethers/lib/utils';
+
+import { signEncoded } from '../../../src/signatures';
+
+import type { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import type { BigNumber } from 'ethers';
+import type { YellowClearingBase } from '../../../typechain';
+
+export interface InteractionPayloadBN {
+  YellowClearing: string;
+  participant: string;
+  nonce: BigNumber;
+}
+
+export interface InteractionPayload {
+  YellowClearing: string;
+  participant: string;
+  nonce: number;
+}
+
+export async function getInteractionPayload(
+  registry: YellowClearingBase,
+  participant: SignerWithAddress,
+): Promise<InteractionPayload> {
+  const IPBN = await registry.getInteractionPayload(participant.address);
+
+  return {
+    YellowClearing: IPBN.YellowClearing,
+    participant: IPBN.participant,
+    nonce: IPBN.nonce.toNumber(),
+  };
+}
+
+export async function signInteractionPayload(
+  interactionPayload: InteractionPayload,
+  signer: SignerWithAddress,
+): Promise<string> {
+  const encodedIP = defaultAbiCoder.encode(
+    [
+      {
+        type: 'tuple',
+        components: [
+          { name: 'YellowClearing', type: 'address' },
+          { name: 'participant', type: 'address' },
+          { name: 'nonce', type: 'uint64' },
+        ],
+      } as ParamType,
+    ],
+    [interactionPayload],
+  );
+  return await signEncoded(signer, encodedIP);
+}
+
+type InteractionParams = [string, string];
+
+export async function getAndSignInteractionPayload(
+  registry: YellowClearingBase,
+  participant: SignerWithAddress,
+): Promise<InteractionParams> {
+  const interactionPayload = await getInteractionPayload(registry, participant);
+  const sig = await signInteractionPayload(interactionPayload, participant);
+  return [participant.address, sig];
+}

--- a/test/clearing/src/participantData.ts
+++ b/test/clearing/src/participantData.ts
@@ -13,14 +13,16 @@ export enum Status {
 }
 
 export interface ParticipantData {
-  registrationTime: number;
   status: BigNumber;
+  nonce: number;
+  registrationTime: number;
 }
 
 export function MockData(status: Status): ParticipantData {
   return {
-    registrationTime: Date.now(),
     status: BigNumber.from(status),
+    nonce: Math.round(Math.random() * 100),
+    registrationTime: Date.now(),
   };
 }
 

--- a/test/clearing/src/transactions.ts
+++ b/test/clearing/src/transactions.ts
@@ -1,15 +1,33 @@
-import { signSelf } from '../../../src/signatures';
+import {
+  InteractionPayload,
+  getAndSignInteractionPayload,
+  signInteractionPayload,
+} from './interactionPayload';
 
 import type { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import type { YellowClearingBase } from '../../../typechain';
 
-export type registerParams = [string, string];
+export type RegisterParams = [string, string];
 
-export async function registerParams(participant: SignerWithAddress): Promise<registerParams> {
-  return [participant.address, await signSelf(participant)];
+export async function registerParams(
+  registry: YellowClearingBase,
+  participant: SignerWithAddress,
+): Promise<RegisterParams> {
+  return await getAndSignInteractionPayload(registry, participant);
 }
 
-export type migrateParams = [string, string];
+export async function registerParamsFromPayload(
+  participant: SignerWithAddress,
+  interactionPayload: InteractionPayload,
+): Promise<RegisterParams> {
+  return [participant.address, await signInteractionPayload(interactionPayload, participant)];
+}
 
-export async function migrateParams(participant: SignerWithAddress): Promise<migrateParams> {
-  return [participant.address, await signSelf(participant)];
+export type MigrateParams = [string, string];
+
+export async function migrateParams(
+  registry: YellowClearingBase,
+  participant: SignerWithAddress,
+): Promise<MigrateParams> {
+  return await getAndSignInteractionPayload(registry, participant);
 }

--- a/test/clearing/src/transactions.ts
+++ b/test/clearing/src/transactions.ts
@@ -1,8 +1,4 @@
-import {
-  InteractionPayload,
-  getAndSignInteractionPayload,
-  signInteractionPayload,
-} from './interactionPayload';
+import { getAndSignIdentityPayload, identityPayload, signIdentityPayload } from './identityPayload';
 
 import type { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import type { YellowClearingBase } from '../../../typechain';
@@ -13,14 +9,14 @@ export async function registerParams(
   registry: YellowClearingBase,
   participant: SignerWithAddress,
 ): Promise<RegisterParams> {
-  return await getAndSignInteractionPayload(registry, participant);
+  return await getAndSignIdentityPayload(registry, participant);
 }
 
 export async function registerParamsFromPayload(
   participant: SignerWithAddress,
-  interactionPayload: InteractionPayload,
+  identityPayload: identityPayload,
 ): Promise<RegisterParams> {
-  return [participant.address, await signInteractionPayload(interactionPayload, participant)];
+  return [participant.address, await signIdentityPayload(identityPayload, participant)];
 }
 
 export type MigrateParams = [string, string];
@@ -29,5 +25,5 @@ export async function migrateParams(
   registry: YellowClearingBase,
   participant: SignerWithAddress,
 ): Promise<MigrateParams> {
-  return await getAndSignInteractionPayload(registry, participant);
+  return await getAndSignIdentityPayload(registry, participant);
 }


### PR DESCRIPTION
# Fix registry sig reusage & other improvements

## Changes

- change required signed data for `registerParticipant` and `migrateParticipant` from just `participant` address to

``` solidity
struct InteractionPayload {
    YellowClearingBase YellowClearing;
    address participant;
    uint64 nonce;
}
```

- introduce `getInteractionPayload(address participant)` function
- change order of fields in `ParticipantData` structure
- extract duplicative code to internal function `_requireParticipantPresent`
- rename `requireParticipantNotPresent` to `requireParticipantNotPresentRecursive`
- store `_prevImplementation` address to allow backwards participant presence check
- add `requireParticipantNotPresentBackwards` and `requireParticipantNotPresentForwards` to be used in `requireParticipantNotPresentRecursive`
- add & change tests